### PR TITLE
Fix promote job: use version-dev tag instead of SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,9 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ github.repository }}
           VERSION: ${{ steps.version.outputs.version }}
-          SHA: ${{ github.sha }}
         run: |
-          echo "Promoting $IMAGE:sha-$SHA → :$VERSION, :latest"
+          echo "Promoting $IMAGE:$VERSION-dev → :$VERSION, :latest"
           docker buildx imagetools create \
             --tag "$IMAGE:$VERSION" \
             --tag "$IMAGE:latest" \
-            "$IMAGE:sha-$SHA"
+            "$IMAGE:$VERSION-dev"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,7 @@ export const DEFAULTS = {
   COMMENT_MAX_RESULTS: 20,
 } as const;
 
-// Available tool groups that operators can enable/disable via the TOOL_GROUPS env var
+// Available tool groups that operators can enable/disable via the ENABLED_TOOL_GROUPS env var
 export const TOOL_GROUPS = [
   'issues', 'projects', 'users', 'boards',
   'sprints', 'epics', 'metadata', 'attachments',


### PR DESCRIPTION
## Summary
- The `promote` job on main was failing because it used `github.sha` (the main merge commit) to locate the dev image, but the image was tagged with the develop commit's SHA during the docker build
- Changed the source tag from `:sha-$SHA` to `:$VERSION-dev`, which is always created by the docker job on develop push and is a stable reference
- Also fixes an incorrect env var name in a comment (`TOOL_GROUPS` → `ENABLED_TOOL_GROUPS`)

## Test plan
- [ ] PR CI passes (build + dependency-review)
- [ ] After merge to develop then main, the promote job should succeed using the `:X.Y.Z-dev` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)