### PR TITLE
Add comprehensive test suite (126 tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,32 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
 
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+
   dependency-review:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -45,7 +71,7 @@ jobs:
           fail-on-severity: high
 
   docker:
-    needs: build
+    needs: [build, test]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/e2e-jira.yml
+++ b/.github/workflows/e2e-jira.yml
@@ -1,0 +1,88 @@
+name: E2E Tests (Jira DC)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 0' # weekly: Sunday 4am UTC
+
+permissions: {}
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 45
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: jiradb
+          POSTGRES_USER: jira
+          POSTGRES_PASSWORD: jira
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U jira"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Start Jira DC container
+        run: |
+          docker run -d \
+            --name jira \
+            --network host \
+            -e ATL_JDBC_URL="jdbc:postgresql://localhost:5432/jiradb" \
+            -e ATL_JDBC_USER=jira \
+            -e ATL_JDBC_PASSWORD=jira \
+            -e ATL_DB_DRIVER="org.postgresql.Driver" \
+            -e ATL_DB_TYPE=postgres72 \
+            -e JVM_MINIMUM_MEMORY=1024m \
+            -e JVM_MAXIMUM_MEMORY=2048m \
+            atlassian/jira-software:9.17
+
+      - name: Wait for Jira to be ready
+        run: npx tsx tests/e2e/setup/wait-for-jira.ts
+        timeout-minutes: 15
+        env:
+          JIRA_BASE_URL: http://localhost:8080
+
+      - name: Complete Jira setup wizard
+        run: npx tsx tests/e2e/setup/complete-setup-wizard.ts
+        env:
+          JIRA_BASE_URL: http://localhost:8080
+          JIRA_LICENSE_KEY: ${{ secrets.JIRA_DC_LICENSE_KEY }}
+
+      - name: Seed test data
+        run: npx tsx tests/e2e/setup/seed-data.ts
+        env:
+          JIRA_BASE_URL: http://localhost:8080
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          JIRA_BASE_URL: http://localhost:8080
+
+      - name: Collect Jira logs on failure
+        if: failure()
+        run: docker logs jira > jira-container.log 2>&1
+
+      - name: Upload Jira logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: jira-logs
+          path: jira-container.log
+          retention-days: 7

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,71 @@
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.0",
+        "@vitest/coverage-v8": "^4.0.18",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.2",
+        "vitest": "^4.0.18"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -477,6 +539,34 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
@@ -517,6 +607,363 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -528,6 +975,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -537,6 +995,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -615,6 +1087,148 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -684,6 +1298,28 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/asynckit": {
@@ -763,6 +1399,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/combined-stream": {
@@ -930,6 +1576,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1005,6 +1658,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1033,6 +1696,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1142,6 +1815,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1304,6 +1995,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1351,6 +2052,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -1424,6 +2132,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -1432,6 +2179,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1444,6 +2198,44 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1502,6 +2294,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1531,6 +2342,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -1571,6 +2393,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1578,6 +2427,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -1657,6 +2535,51 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1688,6 +2611,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1858,6 +2794,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1865,6 +2825,70 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1974,6 +2998,159 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1987,6 +3164,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "start": "node dist/index.js",
     "start:stdio": "TRANSPORT=stdio node dist/index.js",
     "start:http": "TRANSPORT=http node dist/index.js",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "vitest run --config vitest.config.e2e.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
@@ -20,8 +24,10 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.0",
+    "@vitest/coverage-v8": "^4.0.18",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.18"
   },
   "engines": {
     "node": ">=18"

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: jiradb
+      POSTGRES_USER: jira
+      POSTGRES_PASSWORD: jira
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U jira"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  jira:
+    image: atlassian/jira-software:9.17
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ATL_JDBC_URL: "jdbc:postgresql://postgres:5432/jiradb"
+      ATL_JDBC_USER: jira
+      ATL_JDBC_PASSWORD: jira
+      ATL_DB_DRIVER: "org.postgresql.Driver"
+      ATL_DB_TYPE: postgres72
+      JVM_MINIMUM_MEMORY: 1024m
+      JVM_MAXIMUM_MEMORY: 2048m
+    ports:
+      - "8080:8080"
+    volumes:
+      - jiradata:/var/atlassian/application-data/jira
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 180s
+
+volumes:
+  pgdata:
+  jiradata:

--- a/tests/e2e/jira-dc.test.ts
+++ b/tests/e2e/jira-dc.test.ts
@@ -1,0 +1,181 @@
+/**
+ * End-to-end tests against a real Jira Data Center instance.
+ * Requires E2E_SEED_DATA env var (set by seed-data.ts) and
+ * JIRA_BASE_URL + JIRA_PAT pointing to the running Jira instance.
+ *
+ * Run with: npm run test:e2e
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer } from '../../src/server.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+interface SeedData {
+  projectKey: string;
+  issueKeys: string[];
+  boardId: number;
+  sprintId: number;
+}
+
+let client: Client;
+let server: McpServer;
+let seed: SeedData;
+
+beforeAll(async () => {
+  const raw = process.env.E2E_SEED_DATA;
+  if (!raw) throw new Error('E2E_SEED_DATA not set — run seed-data.ts first');
+  seed = JSON.parse(raw);
+
+  // Create real MCP server (no mocks — uses real JiraClient)
+  server = createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: 'e2e-test-client', version: '0.0.1' });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+});
+
+afterAll(async () => {
+  await client?.close();
+  await server?.close();
+});
+
+function getText(result: any): string {
+  return result.content?.[0]?.text ?? '';
+}
+
+describe('E2E: Issue operations', () => {
+  it('should get an issue by key', async () => {
+    const result = await client.callTool({
+      name: 'jira_get_issue',
+      arguments: { issueIdOrKey: seed.issueKeys[0] },
+    });
+    const text = getText(result);
+    expect(text).toContain(seed.issueKeys[0]);
+    expect(text).toContain('E2E Test Bug');
+  });
+
+  it('should search issues via JQL', async () => {
+    const result = await client.callTool({
+      name: 'jira_search_issues',
+      arguments: { jql: `project = ${seed.projectKey}` },
+    });
+    const text = getText(result);
+    for (const key of seed.issueKeys) {
+      expect(text).toContain(key);
+    }
+  });
+
+  it('should retrieve comments on an issue', async () => {
+    const result = await client.callTool({
+      name: 'jira_get_comments',
+      arguments: { issueIdOrKey: seed.issueKeys[0] },
+    });
+    const text = getText(result);
+    expect(text).toContain('test comment');
+  });
+
+  it('should create and delete an issue', async () => {
+    const createResult = await client.callTool({
+      name: 'jira_create_issue',
+      arguments: {
+        projectKey: seed.projectKey,
+        summary: 'E2E Temporary Issue',
+        issueType: 'Task',
+      },
+    });
+    const createText = getText(createResult);
+    expect(createText).toContain('Issue created');
+
+    // Extract the key from "Issue created: TEST-4 (url)"
+    const match = createText.match(/Issue created: (\S+)/);
+    expect(match).toBeTruthy();
+    const newKey = match![1];
+
+    const deleteResult = await client.callTool({
+      name: 'jira_delete_issue',
+      arguments: { issueIdOrKey: newKey },
+    });
+    expect(getText(deleteResult)).toContain('deleted');
+  });
+});
+
+describe('E2E: Project operations', () => {
+  it('should list projects', async () => {
+    const result = await client.callTool({
+      name: 'jira_list_projects',
+      arguments: {},
+    });
+    expect(getText(result)).toContain(seed.projectKey);
+  });
+
+  it('should get project details', async () => {
+    const result = await client.callTool({
+      name: 'jira_get_project',
+      arguments: { projectIdOrKey: seed.projectKey },
+    });
+    expect(getText(result)).toContain('E2E Test Project');
+  });
+});
+
+describe('E2E: Board and Sprint operations', () => {
+  it('should list boards and find the test board', async () => {
+    const result = await client.callTool({
+      name: 'jira_list_boards',
+      arguments: {},
+    });
+    expect(getText(result)).toContain(String(seed.boardId));
+  });
+
+  it('should get sprint details', async () => {
+    const result = await client.callTool({
+      name: 'jira_get_sprint',
+      arguments: { sprintId: seed.sprintId },
+    });
+    const text = getText(result);
+    expect(text).toContain('E2E Test Sprint');
+  });
+
+  it('should list sprint issues', async () => {
+    const result = await client.callTool({
+      name: 'jira_get_sprint_issues',
+      arguments: { sprintId: seed.sprintId },
+    });
+    const text = getText(result);
+    expect(text).toContain(seed.issueKeys[0]);
+  });
+});
+
+describe('E2E: User operations', () => {
+  it('should get the current user', async () => {
+    const result = await client.callTool({
+      name: 'jira_get_myself',
+      arguments: {},
+    });
+    expect(getText(result)).toContain('admin');
+  });
+});
+
+describe('E2E: Metadata operations', () => {
+  it('should list issue types', async () => {
+    const result = await client.callTool({
+      name: 'jira_list_issue_types',
+      arguments: {},
+    });
+    const text = getText(result);
+    expect(text).toContain('Bug');
+    expect(text).toContain('Story');
+  });
+
+  it('should list priorities', async () => {
+    const result = await client.callTool({
+      name: 'jira_list_priorities',
+      arguments: {},
+    });
+    const text = getText(result);
+    expect(text).toContain('High');
+  });
+});

--- a/tests/e2e/setup/complete-setup-wizard.ts
+++ b/tests/e2e/setup/complete-setup-wizard.ts
@@ -1,0 +1,115 @@
+/**
+ * Automates the Jira DC first-run setup wizard via form POSTs.
+ * This is fragile and tied to the pinned Jira version (9.17).
+ * The wizard steps: setup mode → database → app properties → license → admin account → email.
+ */
+import axios, { type AxiosInstance, type AxiosResponse } from 'axios';
+
+const BASE = process.env.JIRA_BASE_URL ?? 'http://localhost:8080';
+const LICENSE = process.env.JIRA_LICENSE_KEY;
+
+if (!LICENSE) {
+  console.error('JIRA_LICENSE_KEY env var is required');
+  process.exit(1);
+}
+
+let cookies: string[] = [];
+
+function extractCookies(res: AxiosResponse): void {
+  const setCookie = res.headers['set-cookie'];
+  if (setCookie) {
+    cookies = [...cookies, ...setCookie.map((c: string) => c.split(';')[0])];
+  }
+}
+
+const client: AxiosInstance = axios.create({
+  baseURL: BASE,
+  maxRedirects: 5,
+  validateStatus: () => true, // don't throw on 3xx/4xx
+  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+});
+
+// Attach cookies to every request
+client.interceptors.request.use(config => {
+  if (cookies.length) {
+    config.headers.Cookie = cookies.join('; ');
+  }
+  return config;
+});
+
+client.interceptors.response.use(res => {
+  extractCookies(res);
+  return res;
+});
+
+async function step1_setupMode(): Promise<void> {
+  await client.get('/secure/SetupMode!default.jspa');
+  await client.post('/secure/SetupMode.jspa', 'setupOption=classic');
+  console.log('Step 1/6: Setup mode → classic');
+}
+
+async function step2_database(): Promise<void> {
+  // Database is pre-configured via environment variables.
+  // POST to confirm the external database configuration.
+  await client.post('/secure/SetupDatabase.jspa',
+    'databaseOption=external&' +
+    'databaseType=postgres72&' +
+    'jdbcHostname=localhost&' +
+    'jdbcPort=5432&' +
+    'jdbcDatabase=jiradb&' +
+    'jdbcUsername=jira&' +
+    'jdbcPassword=jira'
+  );
+  console.log('Step 2/6: Database configured');
+}
+
+async function step3_applicationProperties(): Promise<void> {
+  const params = new URLSearchParams({
+    title: 'Jira E2E Test',
+    mode: 'private',
+    baseURL: BASE,
+  });
+  await client.post('/secure/SetupApplicationProperties.jspa', params.toString());
+  console.log('Step 3/6: Application properties set');
+}
+
+async function step4_license(): Promise<void> {
+  const params = new URLSearchParams({
+    setupLicenseKey: LICENSE!,
+  });
+  await client.post('/secure/SetupLicense.jspa', params.toString());
+  console.log('Step 4/6: License applied');
+}
+
+async function step5_adminAccount(): Promise<void> {
+  const params = new URLSearchParams({
+    username: 'admin',
+    fullname: 'Admin User',
+    email: 'admin@test.local',
+    password: 'admin',
+    confirm: 'admin',
+  });
+  await client.post('/secure/SetupAdminAccount.jspa', params.toString());
+  console.log('Step 5/6: Admin account created');
+}
+
+async function step6_emailNotifications(): Promise<void> {
+  await client.post('/secure/SetupMailNotifications.jspa', 'noemail=true');
+  console.log('Step 6/6: Email notifications skipped');
+}
+
+async function run(): Promise<void> {
+  console.log(`Automating Jira setup wizard at ${BASE}...`);
+  await step1_setupMode();
+  await step2_database();
+  await step3_applicationProperties();
+  await step4_license();
+  await step5_adminAccount();
+  await step6_emailNotifications();
+  console.log('Setup wizard completed successfully!');
+}
+
+run().catch(err => {
+  console.error('Setup wizard failed:', err.message);
+  process.exit(1);
+});

--- a/tests/e2e/setup/seed-data.ts
+++ b/tests/e2e/setup/seed-data.ts
@@ -1,0 +1,124 @@
+/**
+ * Seeds a fresh Jira DC instance with test data via REST API.
+ * Creates a Scrum project, issues, comments, board, and sprint.
+ * Writes seed data manifest to GITHUB_ENV for consumption by e2e tests.
+ */
+import axios from 'axios';
+import { appendFileSync } from 'fs';
+
+const BASE = process.env.JIRA_BASE_URL ?? 'http://localhost:8080';
+
+const client = axios.create({
+  baseURL: BASE,
+  headers: {
+    'Authorization': `Basic ${Buffer.from('admin:admin').toString('base64')}`,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  },
+});
+
+interface SeedResult {
+  projectKey: string;
+  issueKeys: string[];
+  boardId: number;
+  sprintId: number;
+}
+
+async function seedTestData(): Promise<SeedResult> {
+  console.log('Seeding test data...');
+
+  // 1. Create a Scrum project
+  const project = await client.post('/rest/api/2/project', {
+    key: 'TEST',
+    name: 'E2E Test Project',
+    projectTypeKey: 'software',
+    projectTemplateKey: 'com.pyxis.greenhopper.jira:gh-scrum-template',
+    lead: 'admin',
+  });
+  console.log(`Created project: ${project.data.key}`);
+
+  // 2. Create issues
+  const issueDefs = [
+    { summary: 'E2E Test Bug', issuetype: { name: 'Bug' }, priority: { name: 'High' } },
+    { summary: 'E2E Test Story', issuetype: { name: 'Story' }, priority: { name: 'Medium' } },
+    { summary: 'E2E Test Task', issuetype: { name: 'Task' }, priority: { name: 'Low' } },
+  ];
+
+  const issueKeys: string[] = [];
+  for (const def of issueDefs) {
+    const issue = await client.post('/rest/api/2/issue', {
+      fields: {
+        project: { key: 'TEST' },
+        summary: def.summary,
+        issuetype: def.issuetype,
+        priority: def.priority,
+        description: `Automated test issue: ${def.summary}`,
+      },
+    });
+    issueKeys.push(issue.data.key);
+    console.log(`Created issue: ${issue.data.key}`);
+  }
+
+  // 3. Add a comment to the first issue
+  await client.post(`/rest/api/2/issue/${issueKeys[0]}/comment`, {
+    body: 'This is a test comment for e2e testing.',
+  });
+  console.log(`Added comment to ${issueKeys[0]}`);
+
+  // 4. Find the auto-created board (Scrum template creates one)
+  const boards = await client.get('/rest/agile/1.0/board', {
+    params: { projectKeyOrId: 'TEST' },
+  });
+  const boardId = boards.data.values[0]?.id;
+  console.log(`Found board: ${boardId}`);
+
+  // 5. Create a sprint
+  const sprint = await client.post('/rest/agile/1.0/sprint', {
+    name: 'E2E Test Sprint',
+    originBoardId: boardId,
+    goal: 'Automated e2e test sprint',
+  });
+  const sprintId = sprint.data.id;
+  console.log(`Created sprint: ${sprintId}`);
+
+  // 6. Move issues into the sprint
+  await client.post(`/rest/agile/1.0/sprint/${sprintId}/issue`, {
+    issues: issueKeys,
+  });
+  console.log(`Moved ${issueKeys.length} issues to sprint ${sprintId}`);
+
+  const manifest: SeedResult = { projectKey: 'TEST', issueKeys, boardId, sprintId };
+
+  // Write manifest to GITHUB_ENV if running in CI
+  const envFile = process.env.GITHUB_ENV;
+  if (envFile) {
+    appendFileSync(envFile, `E2E_SEED_DATA=${JSON.stringify(manifest)}\n`);
+  }
+
+  // Also write PAT or Basic auth fallback
+  try {
+    const pat = await client.post('/rest/pat/latest/tokens', {
+      name: 'e2e-test-token',
+      expirationDuration: 1,
+    });
+    if (envFile) {
+      appendFileSync(envFile, `JIRA_PAT=${pat.data.rawToken}\n`);
+    }
+    console.log('Created PAT for e2e tests');
+  } catch {
+    // PAT creation not supported; tests will use Basic Auth
+    const basicToken = Buffer.from('admin:admin').toString('base64');
+    if (envFile) {
+      appendFileSync(envFile, `JIRA_PAT=BASIC:${basicToken}\n`);
+    }
+    console.warn('PAT creation not supported; e2e tests will use Basic Auth');
+  }
+
+  console.log('Seed data:', JSON.stringify(manifest, null, 2));
+  return manifest;
+}
+
+seedTestData().catch(err => {
+  console.error('Seed failed:', err.response?.data ?? err.message);
+  process.exit(1);
+});

--- a/tests/e2e/setup/wait-for-jira.ts
+++ b/tests/e2e/setup/wait-for-jira.ts
@@ -1,0 +1,37 @@
+/**
+ * Polls Jira's /status endpoint until the instance is ready.
+ * Jira returns { state: "RUNNING" } when fully set up, or { state: "FIRST_RUN" }
+ * when the setup wizard needs to run. Either state means Jira is accepting requests.
+ */
+import axios from 'axios';
+
+const JIRA_URL = process.env.JIRA_BASE_URL ?? 'http://localhost:8080';
+const MAX_WAIT_MS = 12 * 60 * 1000; // 12 minutes
+const POLL_INTERVAL_MS = 10_000;      // 10 seconds
+
+async function waitForJira(): Promise<void> {
+  const start = Date.now();
+  console.log(`Waiting for Jira at ${JIRA_URL} ...`);
+
+  while (Date.now() - start < MAX_WAIT_MS) {
+    try {
+      const res = await axios.get(`${JIRA_URL}/status`, { timeout: 5000 });
+      const state = res.data?.state;
+      if (state === 'RUNNING' || state === 'FIRST_RUN') {
+        console.log(`Jira is ready (state: ${state}) after ${Math.round((Date.now() - start) / 1000)}s`);
+        return;
+      }
+      console.log(`Jira state: ${state}, waiting...`);
+    } catch (err: unknown) {
+      const code = (err as any).code ?? (err as any).response?.status ?? 'unknown';
+      console.log(`Jira not ready (${code}), retrying in ${POLL_INTERVAL_MS / 1000}s...`);
+    }
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`Jira did not become ready within ${MAX_WAIT_MS / 1000}s`);
+}
+
+waitForJira().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,0 +1,254 @@
+import type {
+  JiraUser, JiraIssue, JiraProject, JiraBoard, JiraSprint, JiraEpic,
+  JiraComment, JiraField, JiraPriority, JiraStatus, JiraIssueType,
+  JiraResolution, JiraFilter, JiraDashboard, JiraAttachment,
+  JiraTransition, JiraWorklog, JiraRemoteLink, JiraComponent, JiraVersion,
+  JiraBoardConfiguration,
+} from '../../src/types.js';
+
+// ── Users ──────────────────────────────────────────────────────────
+
+export const sampleUser: JiraUser = {
+  name: 'jsmith',
+  displayName: 'John Smith',
+  emailAddress: 'jsmith@example.com',
+  active: true,
+  timeZone: 'America/New_York',
+};
+
+export const sampleUser2: JiraUser = {
+  name: 'jdoe',
+  displayName: 'Jane Doe',
+  emailAddress: 'jdoe@example.com',
+  active: true,
+  timeZone: 'Europe/London',
+};
+
+// ── Issues ─────────────────────────────────────────────────────────
+
+export const sampleIssue: JiraIssue = {
+  id: '10001',
+  key: 'PROJ-123',
+  self: 'https://jira.test.example.com/rest/api/2/issue/10001',
+  fields: {
+    summary: 'Fix login bug',
+    status: { name: 'In Progress', id: '3' },
+    priority: { name: 'High', id: '2' },
+    issuetype: { name: 'Bug', id: '1' },
+    assignee: sampleUser,
+    reporter: sampleUser2,
+    created: '2026-01-15T10:00:00.000+0000',
+    updated: '2026-02-20T14:30:00.000+0000',
+    description: 'Users cannot log in with SSO.',
+    project: { key: 'PROJ', name: 'Test Project', id: '10000' },
+    labels: ['sso', 'auth'],
+    components: [{ name: 'Authentication', id: '10100' }],
+    fixVersions: [{ name: '2.0', id: '10200' }],
+  },
+};
+
+export const sampleIssue2: JiraIssue = {
+  id: '10002',
+  key: 'PROJ-124',
+  self: 'https://jira.test.example.com/rest/api/2/issue/10002',
+  fields: {
+    summary: 'Add dark mode',
+    status: { name: 'To Do', id: '1' },
+    priority: { name: 'Medium', id: '3' },
+    issuetype: { name: 'Story', id: '2' },
+    assignee: sampleUser2,
+    reporter: sampleUser,
+  },
+};
+
+export const sampleCreateIssueResponse = {
+  id: '10003',
+  key: 'PROJ-125',
+  self: 'https://jira.test.example.com/rest/api/2/issue/10003',
+};
+
+// ── Projects ───────────────────────────────────────────────────────
+
+export const sampleProject: JiraProject = {
+  id: '10000',
+  key: 'PROJ',
+  name: 'Test Project',
+  description: 'A test project for e2e testing.',
+  lead: sampleUser,
+  projectTypeKey: 'software',
+};
+
+export const sampleProject2: JiraProject = {
+  id: '10001',
+  key: 'OPS',
+  name: 'Operations',
+  lead: sampleUser2,
+  projectTypeKey: 'business',
+};
+
+// ── Components & Versions ──────────────────────────────────────────
+
+export const sampleComponent: JiraComponent = {
+  id: '10100',
+  name: 'Authentication',
+  description: 'Auth module',
+  lead: sampleUser,
+};
+
+export const sampleVersion: JiraVersion = {
+  id: '10200',
+  name: '2.0',
+  description: 'Major release',
+  released: false,
+  archived: false,
+  releaseDate: '2026-06-01',
+};
+
+// ── Boards ─────────────────────────────────────────────────────────
+
+export const sampleBoard: JiraBoard = {
+  id: 42,
+  name: 'PROJ Board',
+  type: 'scrum',
+  location: { projectKey: 'PROJ', projectName: 'Test Project' },
+};
+
+export const sampleBoardConfig: JiraBoardConfiguration = {
+  id: 42,
+  name: 'PROJ Board',
+  filter: { id: '100' },
+  estimation: { type: 'story_points', field: { displayName: 'Story Points' } },
+  columnConfig: {
+    columns: [
+      { name: 'To Do', statuses: [{ id: '1' }] },
+      { name: 'In Progress', statuses: [{ id: '3' }] },
+      { name: 'Done', statuses: [{ id: '5' }] },
+    ],
+  },
+};
+
+// ── Sprints ────────────────────────────────────────────────────────
+
+export const sampleSprint: JiraSprint = {
+  id: 100,
+  name: 'Sprint 10',
+  state: 'active',
+  startDate: '2026-03-01T09:00:00.000Z',
+  endDate: '2026-03-15T17:00:00.000Z',
+  originBoardId: 42,
+  goal: 'Complete auth module',
+};
+
+// ── Epics ──────────────────────────────────────────────────────────
+
+export const sampleEpic: JiraEpic = {
+  id: 10500,
+  key: 'PROJ-100',
+  name: 'Auth Epic',
+  summary: 'All authentication work',
+  done: false,
+  color: { key: 'color_1' },
+};
+
+// ── Comments ───────────────────────────────────────────────────────
+
+export const sampleComment: JiraComment = {
+  id: '20001',
+  author: sampleUser,
+  body: 'This is a test comment.',
+  created: '2026-02-20T14:30:00.000+0000',
+  updated: '2026-02-20T14:30:00.000+0000',
+};
+
+// ── Worklogs ───────────────────────────────────────────────────────
+
+export const sampleWorklog: JiraWorklog = {
+  id: '30001',
+  author: sampleUser,
+  timeSpent: '2h',
+  started: '2026-02-20T10:00:00.000+0000',
+  comment: 'Investigated bug',
+};
+
+// ── Transitions ────────────────────────────────────────────────────
+
+export const sampleTransitions: JiraTransition[] = [
+  { id: '11', name: 'Start Progress', to: { name: 'In Progress', id: '3' } },
+  { id: '21', name: 'Done', to: { name: 'Done', id: '5' } },
+];
+
+// ── Remote Links ───────────────────────────────────────────────────
+
+export const sampleRemoteLink: JiraRemoteLink = {
+  id: 40001,
+  object: { url: 'https://github.com/org/repo/pull/1', title: 'PR #1' },
+  relationship: 'links to',
+};
+
+// ── Metadata ───────────────────────────────────────────────────────
+
+export const sampleField: JiraField = {
+  id: 'summary',
+  name: 'Summary',
+  custom: false,
+  schema: { type: 'string' },
+};
+
+export const sampleCustomField: JiraField = {
+  id: 'customfield_10001',
+  name: 'Story Points',
+  custom: true,
+  schema: { type: 'number' },
+};
+
+export const samplePriority: JiraPriority = {
+  id: '2',
+  name: 'High',
+  description: 'High priority issue',
+};
+
+export const sampleStatus: JiraStatus = {
+  id: '3',
+  name: 'In Progress',
+  description: 'Work is underway',
+  statusCategory: { id: 4, key: 'indeterminate', name: 'In Progress', colorName: 'yellow' },
+};
+
+export const sampleIssueType: JiraIssueType = {
+  id: '1',
+  name: 'Bug',
+  description: 'A defect',
+  subtask: false,
+};
+
+export const sampleResolution: JiraResolution = {
+  id: '1',
+  name: 'Done',
+  description: 'Work is complete',
+};
+
+export const sampleFilter: JiraFilter = {
+  id: '12345',
+  name: 'My Open Bugs',
+  jql: 'project = PROJ AND type = Bug AND status != Done',
+  owner: sampleUser,
+  viewUrl: 'https://jira.test.example.com/issues/?filter=12345',
+};
+
+export const sampleDashboard: JiraDashboard = {
+  id: '50001',
+  name: 'Team Dashboard',
+  view: 'https://jira.test.example.com/secure/Dashboard.jspa?selectPageId=50001',
+};
+
+// ── Attachments ────────────────────────────────────────────────────
+
+export const sampleAttachment: JiraAttachment = {
+  id: '60001',
+  filename: 'screenshot.png',
+  mimeType: 'image/png',
+  size: 12345,
+  author: sampleUser,
+  created: '2026-02-20T14:30:00.000+0000',
+  content: 'https://jira.test.example.com/secure/attachment/60001/screenshot.png',
+};

--- a/tests/helpers/mock-jira-client.ts
+++ b/tests/helpers/mock-jira-client.ts
@@ -1,0 +1,18 @@
+import { vi } from 'vitest';
+
+/**
+ * Creates a mock JiraClient with all HTTP methods stubbed.
+ * Each test can configure return values via mockResolvedValueOnce / mockRejectedValueOnce.
+ */
+export function createMockJiraClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    postMultipart: vi.fn(),
+  };
+}
+
+/** Shared mock instance used by all tool handler tests. */
+export const mockClient = createMockJiraClient();

--- a/tests/helpers/test-server.ts
+++ b/tests/helpers/test-server.ts
@@ -1,0 +1,30 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+/**
+ * Creates an McpServer with the given tool registrar, connects it via
+ * InMemoryTransport, and returns a Client ready to call tools.
+ */
+export async function createTestClient(
+  registerFn: (server: McpServer) => void
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: 'test-server', version: '0.0.1' });
+  registerFn(server);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.1' });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../helpers/mock-jira-client.js';
+
+vi.mock('../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createServer } from '../../src/server.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+/**
+ * Helper: connect a fresh Client to the given McpServer via InMemoryTransport,
+ * list the registered tools, and return the client plus a cleanup function.
+ */
+async function connectClient(server: ReturnType<typeof createServer>) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.1' });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe('Server – tool group filtering', () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedEnv = process.env.ENABLED_TOOL_GROUPS;
+    delete process.env.ENABLED_TOOL_GROUPS;
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env.ENABLED_TOOL_GROUPS = savedEnv;
+    } else {
+      delete process.env.ENABLED_TOOL_GROUPS;
+    }
+  });
+
+  // ── Default: all tool groups ──────────────────────────────────────
+
+  it('registers all 66 tools when ENABLED_TOOL_GROUPS is not set', async () => {
+    const server = createServer();
+    const { client, cleanup } = await connectClient(server);
+
+    try {
+      const { tools } = await client.listTools();
+      expect(tools.length).toBe(66);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── Single group: users ───────────────────────────────────────────
+
+  it('registers only user tools when ENABLED_TOOL_GROUPS=users', async () => {
+    process.env.ENABLED_TOOL_GROUPS = 'users';
+    const server = createServer();
+    const { client, cleanup } = await connectClient(server);
+
+    try {
+      const { tools } = await client.listTools();
+      expect(tools.length).toBe(3);
+
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('jira_get_user');
+      expect(names).toContain('jira_search_users');
+      expect(names).toContain('jira_get_myself');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── Multiple groups: users + issues ───────────────────────────────
+
+  it('registers user + issue tools when ENABLED_TOOL_GROUPS=users,issues', async () => {
+    process.env.ENABLED_TOOL_GROUPS = 'users,issues';
+    const server = createServer();
+    const { client, cleanup } = await connectClient(server);
+
+    try {
+      const { tools } = await client.listTools();
+      // users = 3, issues = 18  =>  21
+      expect(tools.length).toBe(21);
+
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('jira_get_user');
+      expect(names).toContain('jira_create_issue');
+      expect(names).toContain('jira_search_issues');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── Invalid group names are filtered out ──────────────────────────
+
+  it('filters out invalid group names', async () => {
+    process.env.ENABLED_TOOL_GROUPS = 'users,nonexistent,invalid';
+    const server = createServer();
+    const { client, cleanup } = await connectClient(server);
+
+    try {
+      const { tools } = await client.listTools();
+      // Only the valid "users" group should register (3 tools)
+      expect(tools.length).toBe(3);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/tests/integration/tools/attachments.test.ts
+++ b/tests/integration/tools/attachments.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../../helpers/mock-jira-client.js';
+
+vi.mock('../../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createTestClient } from '../../helpers/test-server.js';
+import { registerAttachmentTools } from '../../../src/tools/attachments.js';
+import { sampleAttachment } from '../../helpers/fixtures.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+describe('Attachment Tools', () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const ctx = await createTestClient(registerAttachmentTools);
+    client = ctx.client;
+    cleanup = ctx.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── jira_get_attachment ───────────────────────────────────────────
+
+  it('jira_get_attachment returns attachment metadata', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleAttachment);
+
+    const result = await client.callTool({
+      name: 'jira_get_attachment',
+      arguments: { attachmentId: '60001' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('screenshot.png');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/attachment/60001');
+  });
+
+  // ── jira_delete_attachment ────────────────────────────────────────
+
+  it('jira_delete_attachment deletes an attachment', async () => {
+    mockClient.delete.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_delete_attachment',
+      arguments: { attachmentId: '60001' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Attachment 60001 deleted successfully');
+    expect(mockClient.delete).toHaveBeenCalledWith('/rest/api/2/attachment/60001');
+  });
+
+  // ── jira_add_attachment ───────────────────────────────────────────
+
+  it('jira_add_attachment uploads an attachment', async () => {
+    mockClient.postMultipart.mockResolvedValueOnce([sampleAttachment]);
+
+    const result = await client.callTool({
+      name: 'jira_add_attachment',
+      arguments: {
+        issueIdOrKey: 'PROJ-123',
+        filename: 'screenshot.png',
+        content: Buffer.from('fake image data').toString('base64'),
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('screenshot.png');
+    expect(text).toContain('60001');
+    expect(mockClient.postMultipart).toHaveBeenCalledWith(
+      '/rest/api/2/issue/PROJ-123/attachments',
+      expect.any(FormData),
+    );
+  });
+});

--- a/tests/integration/tools/boards.test.ts
+++ b/tests/integration/tools/boards.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../../helpers/mock-jira-client.js';
+
+vi.mock('../../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createTestClient } from '../../helpers/test-server.js';
+import { registerBoardTools } from '../../../src/tools/boards.js';
+import { sampleBoard, sampleBoardConfig } from '../../helpers/fixtures.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+describe('Board Tools', () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const ctx = await createTestClient(registerBoardTools);
+    client = ctx.client;
+    cleanup = ctx.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── jira_list_boards ──────────────────────────────────────────────
+
+  it('jira_list_boards returns boards', async () => {
+    mockClient.get.mockResolvedValueOnce({
+      values: [sampleBoard],
+      startAt: 0,
+      maxResults: 50,
+      isLast: true,
+    });
+
+    const result = await client.callTool({
+      name: 'jira_list_boards',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ Board');
+    expect(mockClient.get).toHaveBeenCalledWith(
+      '/rest/agile/1.0/board',
+      expect.objectContaining({ startAt: 0, maxResults: 50 }),
+    );
+  });
+
+  // ── jira_get_board ────────────────────────────────────────────────
+
+  it('jira_get_board returns board details', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleBoard);
+
+    const result = await client.callTool({
+      name: 'jira_get_board',
+      arguments: { boardId: 42 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ Board');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/agile/1.0/board/42');
+  });
+
+  // ── jira_get_board_configuration ──────────────────────────────────
+
+  it('jira_get_board_configuration returns board config', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleBoardConfig);
+
+    const result = await client.callTool({
+      name: 'jira_get_board_configuration',
+      arguments: { boardId: 42 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ Board');
+    expect(mockClient.get).toHaveBeenCalledWith(
+      '/rest/agile/1.0/board/42/configuration',
+    );
+  });
+});

--- a/tests/integration/tools/epics.test.ts
+++ b/tests/integration/tools/epics.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../../helpers/mock-jira-client.js';
+
+vi.mock('../../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createTestClient } from '../../helpers/test-server.js';
+import { registerEpicTools } from '../../../src/tools/epics.js';
+import { sampleEpic, sampleIssue } from '../../helpers/fixtures.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+describe('Epic Tools', () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const ctx = await createTestClient(registerEpicTools);
+    client = ctx.client;
+    cleanup = ctx.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── jira_get_epic ─────────────────────────────────────────────────
+
+  it('jira_get_epic returns epic details', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleEpic);
+
+    const result = await client.callTool({
+      name: 'jira_get_epic',
+      arguments: { epicIdOrKey: 'PROJ-100' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Auth Epic');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/agile/1.0/epic/PROJ-100');
+  });
+
+  // ── jira_update_epic (uses POST, not PUT) ─────────────────────────
+
+  it('jira_update_epic updates an epic via POST', async () => {
+    mockClient.post.mockResolvedValueOnce(sampleEpic);
+
+    const result = await client.callTool({
+      name: 'jira_update_epic',
+      arguments: {
+        epicIdOrKey: 'PROJ-100',
+        name: 'Auth Epic',
+        done: false,
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Auth Epic');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/agile/1.0/epic/PROJ-100',
+      { name: 'Auth Epic', done: false },
+    );
+  });
+
+  // ── jira_get_epic_issues ──────────────────────────────────────────
+
+  it('jira_get_epic_issues returns issues in epic', async () => {
+    mockClient.get.mockResolvedValueOnce({
+      issues: [sampleIssue],
+      startAt: 0,
+      maxResults: 50,
+      total: 1,
+      isLast: true,
+    });
+
+    const result = await client.callTool({
+      name: 'jira_get_epic_issues',
+      arguments: { epicIdOrKey: 'PROJ-100' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ-123');
+    expect(mockClient.get).toHaveBeenCalledWith(
+      '/rest/agile/1.0/epic/PROJ-100/issue',
+      expect.objectContaining({ startAt: 0, maxResults: 50 }),
+    );
+  });
+
+  // ── jira_move_issues_to_epic ──────────────────────────────────────
+
+  it('jira_move_issues_to_epic moves issues into an epic', async () => {
+    mockClient.post.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_move_issues_to_epic',
+      arguments: {
+        epicIdOrKey: 'PROJ-100',
+        issues: ['PROJ-123', 'PROJ-124'],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Successfully moved 2 issue(s) to epic PROJ-100');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/agile/1.0/epic/PROJ-100/issue',
+      { issues: ['PROJ-123', 'PROJ-124'] },
+    );
+  });
+
+  // ── jira_remove_issues_from_epic ──────────────────────────────────
+
+  it('jira_remove_issues_from_epic removes issues from their epic', async () => {
+    mockClient.post.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_remove_issues_from_epic',
+      arguments: {
+        issues: ['PROJ-123'],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Successfully removed 1 issue(s) from their epic');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/agile/1.0/epic/none/issue',
+      { issues: ['PROJ-123'] },
+    );
+  });
+});

--- a/tests/integration/tools/issues.test.ts
+++ b/tests/integration/tools/issues.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../../helpers/mock-jira-client.js';
+
+vi.mock('../../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createTestClient } from '../../helpers/test-server.js';
+import { registerIssueTools } from '../../../src/tools/issues.js';
+import {
+  sampleIssue,
+  sampleIssue2,
+  sampleCreateIssueResponse,
+  sampleComment,
+  sampleTransitions,
+} from '../../helpers/fixtures.js';
+import { JiraApiError } from '../../../src/utils/errors.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+describe('Issue Tools', () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const ctx = await createTestClient(registerIssueTools);
+    client = ctx.client;
+    cleanup = ctx.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── jira_create_issue ─────────────────────────────────────────────
+
+  it('jira_create_issue creates an issue and returns key', async () => {
+    mockClient.post.mockResolvedValueOnce(sampleCreateIssueResponse);
+
+    const result = await client.callTool({
+      name: 'jira_create_issue',
+      arguments: {
+        projectKey: 'PROJ',
+        summary: 'New bug',
+        issueType: 'Bug',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Issue created: PROJ-125');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/api/2/issue',
+      {
+        fields: {
+          project: { key: 'PROJ' },
+          summary: 'New bug',
+          issuetype: { name: 'Bug' },
+        },
+      },
+    );
+  });
+
+  // ── jira_get_issue ────────────────────────────────────────────────
+
+  it('jira_get_issue returns issue details', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleIssue);
+
+    const result = await client.callTool({
+      name: 'jira_get_issue',
+      arguments: { issueIdOrKey: 'PROJ-123' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ-123');
+    expect(text).toContain('Fix login bug');
+  });
+
+  // ── jira_search_issues ────────────────────────────────────────────
+
+  it('jira_search_issues returns search results', async () => {
+    mockClient.post.mockResolvedValueOnce({
+      issues: [sampleIssue, sampleIssue2],
+      startAt: 0,
+      maxResults: 25,
+      total: 2,
+    });
+
+    const result = await client.callTool({
+      name: 'jira_search_issues',
+      arguments: { jql: 'project = PROJ' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ-123');
+    expect(text).toContain('PROJ-124');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/api/2/search',
+      expect.objectContaining({ jql: 'project = PROJ' }),
+    );
+  });
+
+  // ── jira_update_issue ─────────────────────────────────────────────
+
+  it('jira_update_issue updates an issue successfully', async () => {
+    mockClient.put.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_update_issue',
+      arguments: {
+        issueIdOrKey: 'PROJ-123',
+        fields: { summary: 'Updated title' },
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ-123 updated successfully');
+    expect(mockClient.put).toHaveBeenCalledWith(
+      '/rest/api/2/issue/PROJ-123',
+      { fields: { summary: 'Updated title' } },
+    );
+  });
+
+  // ── jira_delete_issue ─────────────────────────────────────────────
+
+  it('jira_delete_issue deletes an issue successfully', async () => {
+    mockClient.delete.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_delete_issue',
+      arguments: { issueIdOrKey: 'PROJ-123' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ-123 deleted successfully');
+    expect(mockClient.delete).toHaveBeenCalledWith(
+      '/rest/api/2/issue/PROJ-123?deleteSubtasks=false',
+    );
+  });
+
+  // ── jira_transition_issue ─────────────────────────────────────────
+
+  it('jira_transition_issue transitions an issue', async () => {
+    mockClient.post.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_transition_issue',
+      arguments: {
+        issueIdOrKey: 'PROJ-123',
+        transitionId: '21',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ-123 transitioned successfully');
+    expect(text).toContain('21');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/api/2/issue/PROJ-123/transitions',
+      { transition: { id: '21' } },
+    );
+  });
+
+  // ── jira_get_transitions ──────────────────────────────────────────
+
+  it('jira_get_transitions returns available transitions', async () => {
+    mockClient.get.mockResolvedValueOnce({ transitions: sampleTransitions });
+
+    const result = await client.callTool({
+      name: 'jira_get_transitions',
+      arguments: { issueIdOrKey: 'PROJ-123' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Start Progress');
+    expect(text).toContain('Done');
+  });
+
+  // ── jira_add_comment ──────────────────────────────────────────────
+
+  it('jira_add_comment adds a comment', async () => {
+    mockClient.post.mockResolvedValueOnce(sampleComment);
+
+    const result = await client.callTool({
+      name: 'jira_add_comment',
+      arguments: {
+        issueIdOrKey: 'PROJ-123',
+        body: 'This is a test comment.',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Comment added to PROJ-123');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/api/2/issue/PROJ-123/comment',
+      { body: 'This is a test comment.' },
+    );
+  });
+
+  // ── jira_get_comments ─────────────────────────────────────────────
+
+  it('jira_get_comments returns comments', async () => {
+    mockClient.get.mockResolvedValueOnce({
+      comments: [sampleComment],
+      startAt: 0,
+      maxResults: 20,
+      total: 1,
+    });
+
+    const result = await client.callTool({
+      name: 'jira_get_comments',
+      arguments: { issueIdOrKey: 'PROJ-123' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('This is a test comment.');
+  });
+
+  // ── Error case ────────────────────────────────────────────────────
+
+  it('jira_create_issue returns error when API rejects', async () => {
+    mockClient.post.mockRejectedValueOnce(
+      new JiraApiError('Permission denied', 403),
+    );
+
+    const result = await client.callTool({
+      name: 'jira_create_issue',
+      arguments: {
+        projectKey: 'PROJ',
+        summary: 'Fail',
+        issueType: 'Bug',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('403');
+    expect(text).toContain('Permission denied');
+  });
+});

--- a/tests/integration/tools/metadata.test.ts
+++ b/tests/integration/tools/metadata.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../../helpers/mock-jira-client.js';
+
+vi.mock('../../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createTestClient } from '../../helpers/test-server.js';
+import { registerMetadataTools } from '../../../src/tools/metadata.js';
+import {
+  sampleField,
+  sampleCustomField,
+  samplePriority,
+  sampleStatus,
+  sampleIssueType,
+  sampleResolution,
+  sampleFilter,
+  sampleDashboard,
+} from '../../helpers/fixtures.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+describe('Metadata Tools', () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const ctx = await createTestClient(registerMetadataTools);
+    client = ctx.client;
+    cleanup = ctx.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── jira_list_fields ──────────────────────────────────────────────
+
+  it('jira_list_fields returns system and custom fields', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleField, sampleCustomField]);
+
+    const result = await client.callTool({
+      name: 'jira_list_fields',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Summary');
+    expect(text).toContain('Story Points');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/field');
+  });
+
+  // ── jira_list_priorities ──────────────────────────────────────────
+
+  it('jira_list_priorities returns priorities', async () => {
+    mockClient.get.mockResolvedValueOnce([samplePriority]);
+
+    const result = await client.callTool({
+      name: 'jira_list_priorities',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('High');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/priority');
+  });
+
+  // ── jira_list_statuses ────────────────────────────────────────────
+
+  it('jira_list_statuses returns statuses', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleStatus]);
+
+    const result = await client.callTool({
+      name: 'jira_list_statuses',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('In Progress');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/status');
+  });
+
+  // ── jira_list_issue_types ─────────────────────────────────────────
+
+  it('jira_list_issue_types returns issue types', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleIssueType]);
+
+    const result = await client.callTool({
+      name: 'jira_list_issue_types',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Bug');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/issuetype');
+  });
+
+  // ── jira_list_resolutions ─────────────────────────────────────────
+
+  it('jira_list_resolutions returns resolutions', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleResolution]);
+
+    const result = await client.callTool({
+      name: 'jira_list_resolutions',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Done');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/resolution');
+  });
+
+  // ── jira_get_filter ───────────────────────────────────────────────
+
+  it('jira_get_filter returns filter details', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleFilter);
+
+    const result = await client.callTool({
+      name: 'jira_get_filter',
+      arguments: { filterId: '12345' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('My Open Bugs');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/filter/12345');
+  });
+
+  // ── jira_get_favourite_filters ────────────────────────────────────
+
+  it('jira_get_favourite_filters returns favourite filters', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleFilter]);
+
+    const result = await client.callTool({
+      name: 'jira_get_favourite_filters',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('My Open Bugs');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/filter/favourite');
+  });
+
+  // ── jira_create_filter ────────────────────────────────────────────
+
+  it('jira_create_filter creates a filter', async () => {
+    mockClient.post.mockResolvedValueOnce(sampleFilter);
+
+    const result = await client.callTool({
+      name: 'jira_create_filter',
+      arguments: {
+        name: 'My Open Bugs',
+        jql: 'project = PROJ AND type = Bug AND status != Done',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Filter created: My Open Bugs');
+    expect(text).toContain('12345');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/api/2/filter',
+      expect.objectContaining({
+        name: 'My Open Bugs',
+        jql: 'project = PROJ AND type = Bug AND status != Done',
+      }),
+    );
+  });
+
+  // ── jira_list_dashboards ──────────────────────────────────────────
+
+  it('jira_list_dashboards returns dashboards', async () => {
+    mockClient.get.mockResolvedValueOnce({ dashboards: [sampleDashboard] });
+
+    const result = await client.callTool({
+      name: 'jira_list_dashboards',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Team Dashboard');
+    expect(mockClient.get).toHaveBeenCalledWith(
+      '/rest/api/2/dashboard',
+      expect.objectContaining({ startAt: 0, maxResults: 50 }),
+    );
+  });
+});

--- a/tests/integration/tools/projects.test.ts
+++ b/tests/integration/tools/projects.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../../helpers/mock-jira-client.js';
+
+vi.mock('../../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createTestClient } from '../../helpers/test-server.js';
+import { registerProjectTools } from '../../../src/tools/projects.js';
+import {
+  sampleProject,
+  sampleProject2,
+  sampleComponent,
+  sampleVersion,
+} from '../../helpers/fixtures.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+describe('Project Tools', () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const ctx = await createTestClient(registerProjectTools);
+    client = ctx.client;
+    cleanup = ctx.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── jira_list_projects ────────────────────────────────────────────
+
+  it('jira_list_projects returns all projects', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleProject, sampleProject2]);
+
+    const result = await client.callTool({
+      name: 'jira_list_projects',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Test Project');
+    expect(text).toContain('Operations');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/project');
+  });
+
+  // ── jira_get_project ──────────────────────────────────────────────
+
+  it('jira_get_project returns project details', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleProject);
+
+    const result = await client.callTool({
+      name: 'jira_get_project',
+      arguments: { projectIdOrKey: 'PROJ' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Test Project');
+    expect(text).toContain('PROJ');
+  });
+
+  // ── jira_get_project_components ───────────────────────────────────
+
+  it('jira_get_project_components returns components', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleComponent]);
+
+    const result = await client.callTool({
+      name: 'jira_get_project_components',
+      arguments: { projectIdOrKey: 'PROJ' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Authentication');
+  });
+
+  // ── jira_get_project_versions ─────────────────────────────────────
+
+  it('jira_get_project_versions returns versions', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleVersion]);
+
+    const result = await client.callTool({
+      name: 'jira_get_project_versions',
+      arguments: { projectIdOrKey: 'PROJ' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('2.0');
+  });
+
+  // ── jira_create_component (in place of jira_create_project) ───────
+
+  it('jira_create_component creates a component', async () => {
+    mockClient.post.mockResolvedValueOnce(sampleComponent);
+
+    const result = await client.callTool({
+      name: 'jira_create_component',
+      arguments: {
+        projectKey: 'PROJ',
+        name: 'Authentication',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Authentication');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/api/2/component',
+      expect.objectContaining({ project: 'PROJ', name: 'Authentication' }),
+    );
+  });
+});

--- a/tests/integration/tools/sprints.test.ts
+++ b/tests/integration/tools/sprints.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../../helpers/mock-jira-client.js';
+
+vi.mock('../../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createTestClient } from '../../helpers/test-server.js';
+import { registerSprintTools } from '../../../src/tools/sprints.js';
+import { sampleSprint, sampleIssue } from '../../helpers/fixtures.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+describe('Sprint Tools', () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const ctx = await createTestClient(registerSprintTools);
+    client = ctx.client;
+    cleanup = ctx.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── jira_create_sprint ────────────────────────────────────────────
+
+  it('jira_create_sprint creates a sprint', async () => {
+    mockClient.post.mockResolvedValueOnce(sampleSprint);
+
+    const result = await client.callTool({
+      name: 'jira_create_sprint',
+      arguments: {
+        name: 'Sprint 10',
+        originBoardId: 42,
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Sprint 10');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/agile/1.0/sprint',
+      expect.objectContaining({ name: 'Sprint 10', originBoardId: 42 }),
+    );
+  });
+
+  // ── jira_get_sprint ───────────────────────────────────────────────
+
+  it('jira_get_sprint returns sprint details', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleSprint);
+
+    const result = await client.callTool({
+      name: 'jira_get_sprint',
+      arguments: { sprintId: 100 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Sprint 10');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/agile/1.0/sprint/100');
+  });
+
+  // ── jira_update_sprint ────────────────────────────────────────────
+
+  it('jira_update_sprint updates a sprint', async () => {
+    mockClient.put.mockResolvedValueOnce(sampleSprint);
+
+    const result = await client.callTool({
+      name: 'jira_update_sprint',
+      arguments: {
+        sprintId: 100,
+        name: 'Sprint 10 - Extended',
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Sprint 10');
+    expect(mockClient.put).toHaveBeenCalledWith(
+      '/rest/agile/1.0/sprint/100',
+      { name: 'Sprint 10 - Extended' },
+    );
+  });
+
+  // ── jira_delete_sprint ────────────────────────────────────────────
+
+  it('jira_delete_sprint deletes a sprint', async () => {
+    mockClient.delete.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_delete_sprint',
+      arguments: { sprintId: 100 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Sprint 100 deleted successfully');
+    expect(mockClient.delete).toHaveBeenCalledWith('/rest/agile/1.0/sprint/100');
+  });
+
+  // ── jira_get_sprint_issues ────────────────────────────────────────
+
+  it('jira_get_sprint_issues returns issues in sprint', async () => {
+    mockClient.get.mockResolvedValueOnce({
+      issues: [sampleIssue],
+      startAt: 0,
+      maxResults: 50,
+      total: 1,
+    });
+
+    const result = await client.callTool({
+      name: 'jira_get_sprint_issues',
+      arguments: { sprintId: 100 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('PROJ-123');
+    expect(mockClient.get).toHaveBeenCalledWith(
+      '/rest/agile/1.0/sprint/100/issue',
+      expect.objectContaining({ startAt: 0, maxResults: 50 }),
+    );
+  });
+
+  // ── jira_move_issues_to_sprint ────────────────────────────────────
+
+  it('jira_move_issues_to_sprint moves issues', async () => {
+    mockClient.post.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_move_issues_to_sprint',
+      arguments: {
+        sprintId: 100,
+        issues: ['PROJ-123', 'PROJ-124'],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Successfully moved 2 issue(s) to sprint 100');
+    expect(text).toContain('PROJ-123');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/agile/1.0/sprint/100/issue',
+      { issues: ['PROJ-123', 'PROJ-124'] },
+    );
+  });
+
+  // ── jira_move_issues_to_backlog ───────────────────────────────────
+
+  it('jira_move_issues_to_backlog moves issues to backlog', async () => {
+    mockClient.post.mockResolvedValueOnce(undefined);
+
+    const result = await client.callTool({
+      name: 'jira_move_issues_to_backlog',
+      arguments: {
+        issues: ['PROJ-123'],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('Successfully moved 1 issue(s) to the backlog');
+    expect(text).toContain('PROJ-123');
+    expect(mockClient.post).toHaveBeenCalledWith(
+      '/rest/agile/1.0/backlog/issue',
+      { issues: ['PROJ-123'] },
+    );
+  });
+});

--- a/tests/integration/tools/users.test.ts
+++ b/tests/integration/tools/users.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockClient } from '../../helpers/mock-jira-client.js';
+
+vi.mock('../../../src/services/jira-client.js', () => ({
+  getJiraClient: () => mockClient,
+  JiraClient: vi.fn(),
+}));
+
+import { createTestClient } from '../../helpers/test-server.js';
+import { registerUserTools } from '../../../src/tools/users.js';
+import { sampleUser, sampleUser2 } from '../../helpers/fixtures.js';
+import { JiraApiError } from '../../../src/utils/errors.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+describe('User Tools', () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const ctx = await createTestClient(registerUserTools);
+    client = ctx.client;
+    cleanup = ctx.cleanup;
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  // ── jira_get_user ──────────────────────────────────────────────────
+
+  it('jira_get_user returns user details', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleUser);
+
+    const result = await client.callTool({
+      name: 'jira_get_user',
+      arguments: { username: 'jsmith' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('John Smith');
+    expect(mockClient.get).toHaveBeenCalledWith(
+      '/rest/api/2/user',
+      { username: 'jsmith' },
+    );
+  });
+
+  // ── jira_search_users ─────────────────────────────────────────────
+
+  it('jira_search_users returns matching users', async () => {
+    mockClient.get.mockResolvedValueOnce([sampleUser, sampleUser2]);
+
+    const result = await client.callTool({
+      name: 'jira_search_users',
+      arguments: { query: 'j' },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('John Smith');
+    expect(text).toContain('Jane Doe');
+  });
+
+  // ── jira_get_myself ───────────────────────────────────────────────
+
+  it('jira_get_myself returns current user', async () => {
+    mockClient.get.mockResolvedValueOnce(sampleUser);
+
+    const result = await client.callTool({
+      name: 'jira_get_myself',
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('John Smith');
+    expect(mockClient.get).toHaveBeenCalledWith('/rest/api/2/myself');
+  });
+
+  // ── Error case ────────────────────────────────────────────────────
+
+  it('jira_get_user returns error on 404', async () => {
+    mockClient.get.mockRejectedValueOnce(
+      new JiraApiError('User not found', 404),
+    );
+
+    const result = await client.callTool({
+      name: 'jira_get_user',
+      arguments: { username: 'nonexistent' },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('404');
+    expect(text).toContain('User not found');
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,9 @@
+import { vi, beforeEach } from 'vitest';
+
+// Set required env vars so JiraClient constructor doesn't throw during import
+process.env.JIRA_BASE_URL = 'https://jira.test.example.com';
+process.env.JIRA_PAT = 'test-pat-token';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});

--- a/tests/unit/schemas/common.test.ts
+++ b/tests/unit/schemas/common.test.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+import {
+  PaginationSchema,
+  ResponseFormatSchema,
+  IssueIdOrKeySchema,
+  BoardIdSchema,
+  SprintIdSchema,
+} from '../../../src/schemas/common.js';
+
+describe('PaginationSchema', () => {
+  // PaginationSchema is a plain object with startAt and maxResults fields,
+  // so we wrap it in z.object() to test parsing.
+  const schema = z.object({ ...PaginationSchema });
+
+  it('applies defaults when no values are provided', () => {
+    const result = schema.parse({});
+    expect(result.startAt).toBe(0);
+    expect(result.maxResults).toBe(50);
+  });
+
+  it('accepts valid pagination values', () => {
+    const result = schema.parse({ startAt: 10, maxResults: 25 });
+    expect(result.startAt).toBe(10);
+    expect(result.maxResults).toBe(25);
+  });
+
+  it('rejects negative startAt', () => {
+    expect(() => schema.parse({ startAt: -1 })).toThrow();
+  });
+
+  it('rejects maxResults greater than 100', () => {
+    expect(() => schema.parse({ maxResults: 101 })).toThrow();
+  });
+
+  it('rejects maxResults of 0', () => {
+    expect(() => schema.parse({ maxResults: 0 })).toThrow();
+  });
+
+  it('rejects non-integer startAt', () => {
+    expect(() => schema.parse({ startAt: 1.5 })).toThrow();
+  });
+});
+
+describe('ResponseFormatSchema', () => {
+  it('accepts "markdown"', () => {
+    expect(ResponseFormatSchema.parse('markdown')).toBe('markdown');
+  });
+
+  it('accepts "json"', () => {
+    expect(ResponseFormatSchema.parse('json')).toBe('json');
+  });
+
+  it('defaults to "markdown" when undefined', () => {
+    expect(ResponseFormatSchema.parse(undefined)).toBe('markdown');
+  });
+
+  it('rejects invalid format strings', () => {
+    expect(() => ResponseFormatSchema.parse('xml')).toThrow();
+    expect(() => ResponseFormatSchema.parse('html')).toThrow();
+  });
+});
+
+describe('IssueIdOrKeySchema', () => {
+  it('accepts a valid issue key like "PROJ-123"', () => {
+    expect(IssueIdOrKeySchema.parse('PROJ-123')).toBe('PROJ-123');
+  });
+
+  it('accepts a numeric string ID', () => {
+    expect(IssueIdOrKeySchema.parse('10001')).toBe('10001');
+  });
+
+  it('rejects an empty string', () => {
+    expect(() => IssueIdOrKeySchema.parse('')).toThrow();
+  });
+});
+
+describe('BoardIdSchema', () => {
+  it('accepts a positive integer', () => {
+    expect(BoardIdSchema.parse(42)).toBe(42);
+  });
+
+  it('rejects 0', () => {
+    expect(() => BoardIdSchema.parse(0)).toThrow();
+  });
+
+  it('rejects negative numbers', () => {
+    expect(() => BoardIdSchema.parse(-1)).toThrow();
+  });
+
+  it('rejects floats', () => {
+    expect(() => BoardIdSchema.parse(1.5)).toThrow();
+  });
+});
+
+describe('SprintIdSchema', () => {
+  it('accepts a positive integer', () => {
+    expect(SprintIdSchema.parse(100)).toBe(100);
+  });
+
+  it('rejects 0', () => {
+    expect(() => SprintIdSchema.parse(0)).toThrow();
+  });
+
+  it('rejects negative numbers', () => {
+    expect(() => SprintIdSchema.parse(-5)).toThrow();
+  });
+
+  it('rejects floats', () => {
+    expect(() => SprintIdSchema.parse(3.14)).toThrow();
+  });
+});

--- a/tests/unit/services/formatters.test.ts
+++ b/tests/unit/services/formatters.test.ts
@@ -1,0 +1,222 @@
+import {
+  truncateText,
+  formatToolResponse,
+  formatUser,
+  formatIssue,
+  formatIssueList,
+  formatProject,
+  formatSprint,
+  formatBoard,
+  formatSimpleList,
+} from '../../../src/services/formatters.js';
+import { buildPaginationMeta } from '../../../src/utils/pagination.js';
+import {
+  sampleUser,
+  sampleIssue,
+  sampleIssue2,
+  sampleProject,
+  sampleSprint,
+  sampleBoard,
+  samplePriority,
+  sampleStatus,
+} from '../../helpers/fixtures.js';
+
+describe('truncateText', () => {
+  it('returns short text unchanged', () => {
+    const text = 'Hello, world!';
+    expect(truncateText(text)).toBe(text);
+  });
+
+  it('truncates text exceeding 25000 characters with a truncation message', () => {
+    const longText = 'x'.repeat(30000);
+    const result = truncateText(longText);
+
+    expect(result.length).toBeLessThan(longText.length);
+    expect(result).toContain('... [Response truncated');
+    // The first 25000 characters should be preserved
+    expect(result.startsWith('x'.repeat(25000))).toBe(true);
+  });
+
+  it('returns text exactly at the limit unchanged', () => {
+    const exactText = 'y'.repeat(25000);
+    expect(truncateText(exactText)).toBe(exactText);
+  });
+});
+
+describe('formatToolResponse', () => {
+  it('returns JSON.stringify output when format is "json"', () => {
+    const data = { key: 'PROJ-1', summary: 'Test' };
+    const markdownFn = vi.fn(() => '# Markdown');
+    const result = formatToolResponse(data, 'json', markdownFn);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toBe(JSON.stringify(data, null, 2));
+    expect(markdownFn).not.toHaveBeenCalled();
+  });
+
+  it('calls markdownFn and returns its result when format is "markdown"', () => {
+    const data = { key: 'PROJ-1' };
+    const markdownFn = vi.fn(() => '# Issue PROJ-1');
+    const result = formatToolResponse(data, 'markdown', markdownFn);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toBe('# Issue PROJ-1');
+    expect(markdownFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('formatUser', () => {
+  it('includes displayName, username, and email', () => {
+    const result = formatUser(sampleUser);
+
+    expect(result).toContain('John Smith');
+    expect(result).toContain('jsmith');
+    expect(result).toContain('jsmith@example.com');
+  });
+
+  it('includes active status and timezone', () => {
+    const result = formatUser(sampleUser);
+
+    expect(result).toContain('Active');
+    expect(result).toContain('America/New_York');
+  });
+});
+
+describe('formatIssue', () => {
+  it('includes key, summary, status, and priority', () => {
+    const result = formatIssue(sampleIssue);
+
+    expect(result).toContain('PROJ-123');
+    expect(result).toContain('Fix login bug');
+    expect(result).toContain('In Progress');
+    expect(result).toContain('High');
+  });
+
+  it('includes type, assignee, and reporter', () => {
+    const result = formatIssue(sampleIssue);
+
+    expect(result).toContain('Bug');
+    expect(result).toContain('John Smith');
+    expect(result).toContain('Jane Doe');
+  });
+
+  it('includes labels, components, and fix versions', () => {
+    const result = formatIssue(sampleIssue);
+
+    expect(result).toContain('sso');
+    expect(result).toContain('auth');
+    expect(result).toContain('Authentication');
+    expect(result).toContain('2.0');
+  });
+
+  it('includes description', () => {
+    const result = formatIssue(sampleIssue);
+
+    expect(result).toContain('Description');
+    expect(result).toContain('Users cannot log in with SSO.');
+  });
+});
+
+describe('formatIssueList', () => {
+  it('lists issues and includes pagination footer', () => {
+    const pagination = buildPaginationMeta(0, 50, 2);
+    const result = formatIssueList([sampleIssue, sampleIssue2], pagination);
+
+    expect(result).toContain('PROJ-123');
+    expect(result).toContain('Fix login bug');
+    expect(result).toContain('PROJ-124');
+    expect(result).toContain('Add dark mode');
+    expect(result).toContain('Showing 1-2 of 2');
+  });
+
+  it('shows status and priority for each issue', () => {
+    const pagination = buildPaginationMeta(0, 50, 1);
+    const result = formatIssueList([sampleIssue], pagination);
+
+    expect(result).toContain('In Progress');
+    expect(result).toContain('High');
+  });
+});
+
+describe('formatProject', () => {
+  it('includes name, key, and description', () => {
+    const result = formatProject(sampleProject);
+
+    expect(result).toContain('Test Project');
+    expect(result).toContain('PROJ');
+    expect(result).toContain('A test project for e2e testing.');
+  });
+
+  it('includes lead and project type', () => {
+    const result = formatProject(sampleProject);
+
+    expect(result).toContain('John Smith');
+    expect(result).toContain('software');
+  });
+});
+
+describe('formatSprint', () => {
+  it('includes name, state, and dates', () => {
+    const result = formatSprint(sampleSprint);
+
+    expect(result).toContain('Sprint 10');
+    expect(result).toContain('active');
+    expect(result).toContain('2026-03-01');
+    expect(result).toContain('2026-03-15');
+  });
+
+  it('includes goal', () => {
+    const result = formatSprint(sampleSprint);
+
+    expect(result).toContain('Complete auth module');
+  });
+});
+
+describe('formatBoard', () => {
+  it('includes name, ID, and type', () => {
+    const result = formatBoard(sampleBoard);
+
+    expect(result).toContain('PROJ Board');
+    expect(result).toContain('42');
+    expect(result).toContain('scrum');
+  });
+
+  it('includes project location', () => {
+    const result = formatBoard(sampleBoard);
+
+    expect(result).toContain('PROJ');
+    expect(result).toContain('Test Project');
+  });
+});
+
+describe('formatSimpleList', () => {
+  it('formats a list of priorities', () => {
+    const priorities = [
+      samplePriority,
+      { id: '3', name: 'Medium', description: 'Medium priority' },
+    ];
+    const result = formatSimpleList('Priorities', priorities);
+
+    expect(result).toContain('Priorities (2)');
+    expect(result).toContain('High');
+    expect(result).toContain('High priority issue');
+    expect(result).toContain('Medium');
+  });
+
+  it('formats a list of statuses', () => {
+    const statuses = [sampleStatus];
+    const result = formatSimpleList('Statuses', statuses);
+
+    expect(result).toContain('Statuses (1)');
+    expect(result).toContain('In Progress');
+    expect(result).toContain('Work is underway');
+  });
+
+  it('handles empty list', () => {
+    const result = formatSimpleList('Items', []);
+
+    expect(result).toContain('Items (0)');
+  });
+});

--- a/tests/unit/services/jira-client.test.ts
+++ b/tests/unit/services/jira-client.test.ts
@@ -1,0 +1,226 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const mockAxiosInstance = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => mockAxiosInstance),
+  },
+  AxiosError: class AxiosError extends Error {
+    response?: any;
+    code?: string;
+    constructor(msg: string, code?: string, config?: any, request?: any, response?: any) {
+      super(msg);
+      this.name = 'AxiosError';
+      this.code = code;
+      this.response = response;
+    }
+    isAxiosError = true;
+  },
+}));
+
+import { JiraClient } from '../../../src/services/jira-client.js';
+import { JiraApiError } from '../../../src/utils/errors.js';
+import { AxiosError } from 'axios';
+
+describe('JiraClient', () => {
+  let client: JiraClient;
+
+  beforeEach(() => {
+    // Env vars are set in tests/setup.ts; reset mocks between tests
+    mockAxiosInstance.get.mockReset();
+    mockAxiosInstance.post.mockReset();
+    mockAxiosInstance.put.mockReset();
+    mockAxiosInstance.delete.mockReset();
+    client = new JiraClient();
+  });
+
+  describe('constructor', () => {
+    it('reads JIRA_BASE_URL and JIRA_PAT from environment', () => {
+      // If the constructor didn't throw, it successfully read the env vars.
+      expect(client).toBeInstanceOf(JiraClient);
+    });
+
+    it('throws when JIRA_BASE_URL is missing', () => {
+      const origUrl = process.env.JIRA_BASE_URL;
+      delete process.env.JIRA_BASE_URL;
+      try {
+        expect(() => new JiraClient()).toThrow('JIRA_BASE_URL environment variable is required');
+      } finally {
+        process.env.JIRA_BASE_URL = origUrl;
+      }
+    });
+
+    it('throws when JIRA_PAT is missing', () => {
+      const origPat = process.env.JIRA_PAT;
+      delete process.env.JIRA_PAT;
+      try {
+        expect(() => new JiraClient()).toThrow('JIRA_PAT environment variable is required');
+      } finally {
+        process.env.JIRA_PAT = origPat;
+      }
+    });
+  });
+
+  describe('get', () => {
+    it('returns response.data on success', async () => {
+      const data = { id: '10001', key: 'PROJ-123' };
+      mockAxiosInstance.get.mockResolvedValue({ data });
+
+      const result = await client.get('/rest/api/2/issue/PROJ-123');
+
+      expect(result).toEqual(data);
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/rest/api/2/issue/PROJ-123', { params: undefined });
+    });
+
+    it('passes query params to axios', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: {} });
+
+      await client.get('/rest/api/2/search', { jql: 'project=PROJ', maxResults: 10 });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/rest/api/2/search', {
+        params: { jql: 'project=PROJ', maxResults: 10 },
+      });
+    });
+  });
+
+  describe('post', () => {
+    it('sends data and returns response.data', async () => {
+      const reqBody = { fields: { summary: 'New issue' } };
+      const resData = { id: '10003', key: 'PROJ-125' };
+      mockAxiosInstance.post.mockResolvedValue({ data: resData });
+
+      const result = await client.post('/rest/api/2/issue', reqBody);
+
+      expect(result).toEqual(resData);
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/rest/api/2/issue', reqBody);
+    });
+  });
+
+  describe('put', () => {
+    it('sends data and returns response.data', async () => {
+      const reqBody = { fields: { summary: 'Updated' } };
+      const resData = { id: '10001' };
+      mockAxiosInstance.put.mockResolvedValue({ data: resData });
+
+      const result = await client.put('/rest/api/2/issue/PROJ-123', reqBody);
+
+      expect(result).toEqual(resData);
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/rest/api/2/issue/PROJ-123', reqBody);
+    });
+  });
+
+  describe('delete', () => {
+    it('returns response.data on success', async () => {
+      mockAxiosInstance.delete.mockResolvedValue({ data: undefined });
+
+      const result = await client.delete('/rest/api/2/issue/PROJ-123');
+
+      expect(result).toBeUndefined();
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/rest/api/2/issue/PROJ-123');
+    });
+  });
+
+  describe('error mapping', () => {
+    it('maps 400 to "Bad request"', async () => {
+      const axiosErr = new AxiosError('Request failed', '400', undefined, undefined, {
+        status: 400,
+        data: { errorMessages: ['Invalid field'], errors: { summary: 'Field is required' } },
+      });
+      mockAxiosInstance.get.mockRejectedValue(axiosErr);
+
+      await expect(client.get('/test')).rejects.toThrow(JiraApiError);
+      await expect(client.get('/test')).rejects.toThrow(/Bad request/);
+    });
+
+    it('maps 401 to "Authentication failed"', async () => {
+      const axiosErr = new AxiosError('Unauthorized', '401', undefined, undefined, {
+        status: 401,
+        data: { errorMessages: [], errors: {} },
+      });
+      mockAxiosInstance.get.mockRejectedValue(axiosErr);
+
+      await expect(client.get('/test')).rejects.toThrow(JiraApiError);
+      await expect(client.get('/test')).rejects.toThrow(/Authentication failed/);
+    });
+
+    it('maps 403 to "Permission denied"', async () => {
+      const axiosErr = new AxiosError('Forbidden', '403', undefined, undefined, {
+        status: 403,
+        data: { errorMessages: [], errors: {} },
+      });
+      mockAxiosInstance.get.mockRejectedValue(axiosErr);
+
+      await expect(client.get('/test')).rejects.toThrow(JiraApiError);
+      await expect(client.get('/test')).rejects.toThrow(/Permission denied/);
+    });
+
+    it('maps 404 to "Not found"', async () => {
+      const axiosErr = new AxiosError('Not Found', '404', undefined, undefined, {
+        status: 404,
+        data: { errorMessages: ['Issue Does Not Exist'], errors: {} },
+      });
+      mockAxiosInstance.get.mockRejectedValue(axiosErr);
+
+      await expect(client.get('/test')).rejects.toThrow(JiraApiError);
+      await expect(client.get('/test')).rejects.toThrow(/Not found/);
+    });
+
+    it('maps ECONNABORTED to "Request timed out"', async () => {
+      const axiosErr = new AxiosError('timeout', 'ECONNABORTED');
+      mockAxiosInstance.get.mockRejectedValue(axiosErr);
+
+      await expect(client.get('/test')).rejects.toThrow(JiraApiError);
+      await expect(client.get('/test')).rejects.toThrow(/Request timed out/);
+    });
+
+    it('maps ECONNREFUSED to "Connection refused"', async () => {
+      const axiosErr = new AxiosError('connect failed', 'ECONNREFUSED');
+      mockAxiosInstance.get.mockRejectedValue(axiosErr);
+
+      await expect(client.get('/test')).rejects.toThrow(JiraApiError);
+      await expect(client.get('/test')).rejects.toThrow(/Connection refused/);
+    });
+
+    it('preserves jiraErrors and jiraFieldErrors from response body', async () => {
+      const axiosErr = new AxiosError('Bad request', '400', undefined, undefined, {
+        status: 400,
+        data: {
+          errorMessages: ['JQL parse error', 'Another error'],
+          errors: { assignee: 'User does not exist' },
+        },
+      });
+      mockAxiosInstance.get.mockRejectedValue(axiosErr);
+
+      try {
+        await client.get('/test');
+        expect.unreachable('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(JiraApiError);
+        const jiraErr = err as JiraApiError;
+        expect(jiraErr.statusCode).toBe(400);
+        expect(jiraErr.jiraErrors).toEqual(['JQL parse error', 'Another error']);
+        expect(jiraErr.jiraFieldErrors).toEqual({ assignee: 'User does not exist' });
+      }
+    });
+
+    it('wraps generic Error into JiraApiError', async () => {
+      mockAxiosInstance.get.mockRejectedValue(new Error('Something unexpected'));
+
+      await expect(client.get('/test')).rejects.toThrow(JiraApiError);
+      await expect(client.get('/test')).rejects.toThrow(/Something unexpected/);
+    });
+
+    it('wraps non-Error values into JiraApiError', async () => {
+      mockAxiosInstance.get.mockRejectedValue('string error');
+
+      await expect(client.get('/test')).rejects.toThrow(JiraApiError);
+      await expect(client.get('/test')).rejects.toThrow(/string error/);
+    });
+  });
+});

--- a/tests/unit/utils/errors.test.ts
+++ b/tests/unit/utils/errors.test.ts
@@ -1,0 +1,94 @@
+import { JiraApiError, buildErrorResult } from '../../../src/utils/errors.js';
+
+describe('JiraApiError', () => {
+  it('stores statusCode, message, jiraErrors, and jiraFieldErrors', () => {
+    const err = new JiraApiError('Bad request', 400, ['field X is invalid'], { summary: 'required' });
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(JiraApiError);
+    expect(err.name).toBe('JiraApiError');
+    expect(err.message).toBe('Bad request');
+    expect(err.statusCode).toBe(400);
+    expect(err.jiraErrors).toEqual(['field X is invalid']);
+    expect(err.jiraFieldErrors).toEqual({ summary: 'required' });
+  });
+
+  it('defaults jiraErrors and jiraFieldErrors to undefined when not provided', () => {
+    const err = new JiraApiError('Not found', 404);
+
+    expect(err.statusCode).toBe(404);
+    expect(err.jiraErrors).toBeUndefined();
+    expect(err.jiraFieldErrors).toBeUndefined();
+  });
+});
+
+describe('buildErrorResult', () => {
+  it('formats JiraApiError with details (jiraErrors and jiraFieldErrors)', () => {
+    const err = new JiraApiError(
+      'Bad request',
+      400,
+      ['Invalid JQL query'],
+      { assignee: 'User not found' },
+    );
+    const result = buildErrorResult(err);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Error (400)');
+    expect(result.content[0].text).toContain('Bad request');
+    expect(result.content[0].text).toContain('Details: Invalid JQL query');
+    expect(result.content[0].text).toContain('Field errors:');
+    expect(result.content[0].text).toContain('User not found');
+  });
+
+  it('formats JiraApiError without details', () => {
+    const err = new JiraApiError('Not found', 404);
+    const result = buildErrorResult(err);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('Error (404)');
+    expect(result.content[0].text).toContain('Not found');
+    // Should NOT contain "Details:" or "Field errors:" since there are none
+    expect(result.content[0].text).not.toContain('Details:');
+    expect(result.content[0].text).not.toContain('Field errors:');
+  });
+
+  it('formats a generic Error', () => {
+    const err = new Error('Something went wrong');
+    const result = buildErrorResult(err);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toBe('Error: Something went wrong');
+  });
+
+  it('formats a non-Error value (string)', () => {
+    const result = buildErrorResult('random failure');
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toBe('Unexpected error: random failure');
+  });
+
+  it('always returns isError: true and content[0].type === "text"', () => {
+    const cases: unknown[] = [
+      new JiraApiError('a', 500),
+      new Error('b'),
+      'c',
+      42,
+      null,
+      undefined,
+    ];
+
+    for (const value of cases) {
+      const result = buildErrorResult(value);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].type).toBe('text');
+    }
+  });
+});

--- a/tests/unit/utils/pagination.test.ts
+++ b/tests/unit/utils/pagination.test.ts
@@ -1,0 +1,81 @@
+import { buildPaginationMeta, formatPaginationFooter } from '../../../src/utils/pagination.js';
+
+describe('buildPaginationMeta', () => {
+  it('computes middle page correctly', () => {
+    const meta = buildPaginationMeta(50, 50, 200);
+
+    expect(meta.startAt).toBe(50);
+    expect(meta.maxResults).toBe(50);
+    expect(meta.total).toBe(200);
+    expect(meta.isLastPage).toBe(false);
+    expect(meta.nextStartAt).toBe(100);
+  });
+
+  it('computes last page correctly', () => {
+    const meta = buildPaginationMeta(150, 50, 200);
+
+    expect(meta.startAt).toBe(150);
+    expect(meta.maxResults).toBe(50);
+    expect(meta.total).toBe(200);
+    expect(meta.isLastPage).toBe(true);
+    expect(meta.nextStartAt).toBeNull();
+  });
+
+  it('computes first and only page correctly', () => {
+    const meta = buildPaginationMeta(0, 50, 10);
+
+    expect(meta.startAt).toBe(0);
+    expect(meta.maxResults).toBe(50);
+    expect(meta.total).toBe(10);
+    expect(meta.isLastPage).toBe(true);
+    expect(meta.nextStartAt).toBeNull();
+  });
+
+  it('treats exact boundary (startAt + maxResults === total) as last page', () => {
+    const meta = buildPaginationMeta(150, 50, 200);
+
+    expect(meta.isLastPage).toBe(true);
+    expect(meta.nextStartAt).toBeNull();
+  });
+
+  it('handles zero total results', () => {
+    const meta = buildPaginationMeta(0, 50, 0);
+
+    expect(meta.isLastPage).toBe(true);
+    expect(meta.nextStartAt).toBeNull();
+  });
+});
+
+describe('formatPaginationFooter', () => {
+  it('includes "Showing X-Y of Z" and "Last page" for the last page', () => {
+    const meta = buildPaginationMeta(150, 50, 200);
+    const footer = formatPaginationFooter(meta);
+
+    expect(footer).toContain('Showing 151-200 of 200');
+    expect(footer).toContain('Last page');
+  });
+
+  it('includes "Showing X-Y of Z" and "Next page: startAt=..." for a middle page', () => {
+    const meta = buildPaginationMeta(50, 50, 200);
+    const footer = formatPaginationFooter(meta);
+
+    expect(footer).toContain('Showing 51-100 of 200');
+    expect(footer).toContain('Next page: startAt=100');
+  });
+
+  it('shows correct range when total is smaller than page size', () => {
+    const meta = buildPaginationMeta(0, 50, 10);
+    const footer = formatPaginationFooter(meta);
+
+    expect(footer).toContain('Showing 1-10 of 10');
+    expect(footer).toContain('Last page');
+  });
+
+  it('shows correct range for the first page of a multi-page result', () => {
+    const meta = buildPaginationMeta(0, 50, 200);
+    const footer = formatPaginationFooter(meta);
+
+    expect(footer).toContain('Showing 1-50 of 200');
+    expect(footer).toContain('Next page: startAt=50');
+  });
+});

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/e2e/**/*.test.ts'],
+    globals: true,
+    environment: 'node',
+    testTimeout: 60_000,
+    hookTimeout: 120_000,
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+    retry: 1,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/unit/**/*.test.ts', 'tests/integration/**/*.test.ts'],
+    exclude: ['tests/e2e/**'],
+    globals: true,
+    environment: 'node',
+    setupFiles: ['./tests/setup.ts'],
+    testTimeout: 10_000,
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/index.ts'],
+      reporter: ['text', 'lcov', 'json-summary'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds vitest test framework with 126 tests across 14 test files
- **Unit tests** (76): errors, pagination, Zod schemas, formatters, JiraClient
- **Integration tests** (50): all 8 tool groups tested via MCP InMemoryTransport, plus server tool group filtering
- **E2E infrastructure**: Docker Compose with Jira DC 9.17 + PostgreSQL, automated setup wizard, data seeding, critical-path tests
- CI workflow updated: `test` job runs before Docker build, uploads coverage artifact
- E2E tests run on separate workflow (weekly schedule + manual trigger)

## Test breakdown
| Category | Files | Tests |
|----------|-------|-------|
| Unit: utils | 2 | 16 |
| Unit: schemas | 1 | 21 |
| Unit: services | 2 | 39 |
| Integration: tools | 8 | 46 |
| Integration: server | 1 | 4 |
| **Total** | **14** | **126** |

All tests pass in ~1 second.

## Test plan
- [x] `npm test` — all 126 tests pass locally
- [x] `npm run build` — TypeScript compilation passes
- [ ] CI runs build + test jobs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)